### PR TITLE
VZ-1299 Conditionally include version_string in base_url for connecton

### DIFF
--- a/lib/hyper/core/service.rb
+++ b/lib/hyper/core/service.rb
@@ -23,7 +23,7 @@ module Hyper
           yield(configuration)
         end
 
-        def connection(&blk)
+        def connection(versioned_base_url = true, &blk)
           block = blk || Proc.new do |faraday|
             faraday.request :url_encoded # form-encode POST params
             faraday.headers['X-Entity-Email'] = configuration.email
@@ -32,7 +32,7 @@ module Hyper
             faraday.headers['Content-Type'] = 'application/json'
             faraday.adapter Faraday.default_adapter # make requests with Net::HTTP
           end
-          Faraday.new(url: configuration.base_url, &block)
+          Faraday.new(url: configuration.base_url(versioned_base_url), &block)
         end
       end
     end

--- a/lib/hyper/core/service/client/dispatcher.rb
+++ b/lib/hyper/core/service/client/dispatcher.rb
@@ -11,7 +11,7 @@ module Hyper
           @arguments = arguments
           @options = options
           @object_key ||= options.key?(:object_key) ? options.delete(:object_key) : endpoint
-          @connection = Hyper::Core::Service.connection
+          @connection = Hyper::Core::Service.connection(versioned_base_url)
         end
 
         def call
@@ -51,6 +51,10 @@ module Hyper
           when (500..599)
             raise InternalServerError, response.body
           end
+        end
+
+        def versioned_base_url
+          !endpoint.include?(Hyper::Core::Service::Configuration::NON_VERSIONED_API_PATH)
         end
       end
     end

--- a/lib/hyper/core/service/configuration.rb
+++ b/lib/hyper/core/service/configuration.rb
@@ -6,6 +6,7 @@ module Hyper
         PREFIX = 'api'
         API_VERSION = 3
         PRODUCT = 'engage'
+        NON_VERSIONED_API_PATH = 'visualize'
 
         attr_writer :host, :prefix, :version, :product
         attr_accessor :email, :token, :organization_id
@@ -26,11 +27,19 @@ module Hyper
           @product ||= PRODUCT
         end
 
-        def base_url
-          "#{protocol}#{host}/#{prefix}/#{version_string}"
+        def base_url(versioned_base_url = true)
+          versioned_base_url ? base_url_with_version : base_url_without_version
         end
 
         private
+
+        def base_url_with_version
+          "#{protocol}#{host}/#{prefix}/#{version_string}"
+        end
+
+        def base_url_without_version
+          "#{protocol}#{host}/#{prefix}"
+        end
 
         def protocol
           'https://'

--- a/spec/core/service/client/dispatcher_spec.rb
+++ b/spec/core/service/client/dispatcher_spec.rb
@@ -19,6 +19,23 @@ RSpec.describe Hyper::Core::Service::Dispatcher do
     end
   end
 
+  describe '#connection' do
+    context 'when endpoint includes non-versioned path' do
+      let(:non_versioned_path) { Hyper::Core::Service::Configuration::NON_VERSIONED_API_PATH }
+      let(:endpoint) { "#{non_versioned_path}/foos"}
+
+      it 'does not include version in the connection url' do
+        expect(subject.connection.path_prefix).to eq('/api')
+      end
+    end
+
+    context 'when endpoint does not include a non-versioned path' do
+      it 'includes version in the connection url' do
+        expect(subject.connection.path_prefix).to eq('/api/v3')
+      end
+    end
+  end
+
   describe '#response' do
     before do
       allow(subject.connection).to receive(:get).and_call_original


### PR DESCRIPTION
The base of work for this ticket was creating a new `/visualize/users` endpoint in Engage.

But that caused problems using Core because it always expects a `version_string` and the `/visualize` namespace does not include a version.

This inspects the resource_url for the request and conditionally sets the base_url with or without a version string as necessary.